### PR TITLE
FIX: Staff restricted tag logic

### DIFF
--- a/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -40,7 +40,7 @@ export default class SidebarNewTopicButton extends Component {
   }
 
   get tagRestricted() {
-    return this.tag?.staff;
+    return this.tag?.staff && !this.currentUser.staff;
   }
 
   get createTopicDisabled() {

--- a/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -45,7 +45,8 @@ export default class SidebarNewTopicButton extends Component {
 
   get createTopicDisabled() {
     return (
-      (this.category && !this.createTopicTargetCategory) || (this.tagRestricted && !this.currentUser.staff)
+      (this.category && !this.createTopicTargetCategory) ||
+      (this.tagRestricted && !this.currentUser.staff)
     );
   }
 

--- a/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -45,7 +45,7 @@ export default class SidebarNewTopicButton extends Component {
 
   get createTopicDisabled() {
     return (
-      (this.category && !this.createTopicTargetCategory) || (this.tagRestricted && !this.currentUser.staff)
+      (this.category && !this.createTopicTargetCategory) || (this.tagRestricted && !this.currentUser.staff);
     );
   }
 

--- a/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -45,7 +45,7 @@ export default class SidebarNewTopicButton extends Component {
 
   get createTopicDisabled() {
     return (
-      (this.category && !this.createTopicTargetCategory) || (this.tagRestricted && !this.currentUser.staff);
+      (this.category && !this.createTopicTargetCategory) || (this.tagRestricted && !this.currentUser.staff)
     );
   }
 

--- a/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -40,12 +40,12 @@ export default class SidebarNewTopicButton extends Component {
   }
 
   get tagRestricted() {
-    return this.tag?.staff && !this.currentUser.staff;
+    return this.tag?.staff;
   }
 
   get createTopicDisabled() {
     return (
-      (this.category && !this.createTopicTargetCategory) || this.tagRestricted
+      (this.category && !this.createTopicTargetCategory) || (this.tagRestricted && !this.currentUser.staff)
     );
   }
 


### PR DESCRIPTION
Adjusts the logic so that a tag restricted to staff is *not* considered restricted if the current user is staff.

Inverse of the logic [here](https://github.com/discourse/discourse/blob/6fc5ce968892b980c3db6b19b49683fb38a59e29/app/assets/javascripts/discourse/app/routes/tag-show.js#L151) in core:
```js
canCreateTopicOnTag: !tag.staff || this.currentUser?.staff
```

Internal topic: t/-/151640